### PR TITLE
Node Campaigns: Specify Text Format

### DIFF
--- a/modules/mailjet_simple_node_campaigns/includes/mailjet_simple_node_campaigns.admin.inc
+++ b/modules/mailjet_simple_node_campaigns/includes/mailjet_simple_node_campaigns.admin.inc
@@ -19,6 +19,28 @@ function mailjet_simple_node_campaigns_admin_settings_form($form) {
       '#tree' => TRUE,
     );
 
+    // Create a list of available text_formats.
+    $text_formats = array(NULL => t('- None -'));
+    foreach (filter_formats() as $key => $text_format) {
+      $text_formats[$key] = $text_format->name;
+    }
+
+    // Build a fieldset of advanced options.
+    $form['mailjet_simple_node_campaigns_settings']['advanced_settings'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Advanced Settings'),
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    );
+
+    $form['mailjet_simple_node_campaigns_settings']['advanced_settings']['text_format'] = array(
+      '#type' => 'select',
+      '#title' => t('Text Format'),
+      '#options' => $text_formats,
+      '#default_value' => !empty($node_campaign_settings['advanced_settings']['text_format']) ? $node_campaign_settings['advanced_settings']['text_format'] : 0,
+      '#description' => t('Select the text format that you would like to use to sanitize your node campaign content with. To create a new text format, visit the <a href="@url">text format administration page</a>.', array('@url' => url('admin/config/content/formats'))),
+    );
+
     // Create a list of mailjet lists.
     $lists = array(0 => t('- Disabled -')) + mailjet_simple_options_list();
 

--- a/modules/mailjet_simple_node_campaigns/includes/mailjet_simple_node_campaigns.admin.inc
+++ b/modules/mailjet_simple_node_campaigns/includes/mailjet_simple_node_campaigns.admin.inc
@@ -37,7 +37,7 @@ function mailjet_simple_node_campaigns_admin_settings_form($form) {
       '#type' => 'select',
       '#title' => t('Text Format'),
       '#options' => $text_formats,
-      '#default_value' => !empty($node_campaign_settings['advanced_settings']['text_format']) ? $node_campaign_settings['advanced_settings']['text_format'] : 0,
+      '#default_value' => !empty($node_campaign_settings['advanced_settings']['text_format']) ? $node_campaign_settings['advanced_settings']['text_format'] : NULL,
       '#description' => t('Select the text format that you would like to use to sanitize your node campaign content with. To create a new text format, visit the <a href="@url">text format administration page</a>.', array('@url' => url('admin/config/content/formats'))),
     );
 

--- a/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
+++ b/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
@@ -151,12 +151,16 @@ function mailjet_simple_node_campaigns_form_node_form_submit($form, &$form_state
 /**
  * Helper function that returns the specified node campaign setting.
  */
-function mailjet_simple_node_campaigns_get_setting($setting) {
+function mailjet_simple_node_campaigns_get_setting($setting = NULL) {
+  // Load all node campaign settings.
+  $settings = variable_get('mailjet_simple_node_campaigns_settings');
+
+  // If a setting is requested in this function call return it.
   if (!empty($setting)) {
-    $settings = variable_get('mailjet_simple_node_campaigns_settings');
-    $result = $settings[$setting];
-    return $result;
+    return !empty($settings[$setting]) ? $settings[$setting] : FALSE;
   }
+
+  return $settings;
 }
 
 

--- a/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
+++ b/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
@@ -141,7 +141,7 @@ function mailjet_simple_node_campaigns_form_node_form_submit($form, &$form_state
 
     // Specify the text format to be used when sanitizing the message.
     $advanced_settings = mailjet_simple_node_campaigns_get_setting('advanced_settings');
-    $text_format = $advanced_settings['text_format'] ? $advanced_settings['text_format'] : NULL;
+    $text_format = !(empty($advanced_settings['text_format'])) ? $advanced_settings['text_format'] : NULL;
 
     // Send the node campaign.
     mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, $message, $template_id, $text_format, $arguments);

--- a/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
+++ b/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
@@ -139,7 +139,23 @@ function mailjet_simple_node_campaigns_form_node_form_submit($form, &$form_state
       $arguments['SenderEmail'] = check_plain($form_state['values']['node_campaign_settings_overrides']['node_campaign_email']);
     }
 
-    mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, $message, $template_id, $arguments);
+    // Specify the text format to be used when sanitizing the message.
+    $advanced_settings = mailjet_simple_node_campaigns_get_setting('advanced_settings');
+    $text_format = $advanced_settings['text_format'] ? $advanced_settings['text_format'] : NULL;
+
+    // Send the node campaign.
+    mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, $message, $template_id, $text_format, $arguments);
+  }
+}
+
+/**
+ * Helper function that returns the specified node campaign setting.
+ */
+function mailjet_simple_node_campaigns_get_setting($setting) {
+  if (!empty($setting)) {
+    $settings = variable_get('mailjet_simple_node_campaigns_settings');
+    $result = $settings[$setting];
+    return $result;
   }
 }
 
@@ -240,6 +256,12 @@ function mailjet_simple_node_campaigns_get_template_detail($template_id) {
  * @param string $message
  *    Content to be posted as message on associated campaign.
  *
+ * @param string $template_id
+ *    The ID fo the template to be associated with the campaign.
+ *
+ * @param string $text_format
+ *    The text format to be used to sanitize $mailjet_template_vars values.
+ *
  * @param array $arguments
  *    An array of additional arguments used to prepare the campaign.
  *    https://dev.mailjet.com/email-api/v3/campaigndraft/
@@ -252,7 +274,7 @@ function mailjet_simple_node_campaigns_get_template_detail($template_id) {
  *      'SenderEmail' => "sender@email.address",
  *    );
  */
-function mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, $message, $template_id = NULL, array $arguments) {
+function mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, $message, $template_id = NULL, $text_format = NULL, array $arguments) {
   // Define Mailjet campaign defaults.
   $argument_defaults = array(
     'ContactsListID' => "$list_id",
@@ -299,7 +321,7 @@ function mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, 
         $html_message = $detail[0]['Html-part'];
         $text_message = $detail[0]['Text-part'];
         foreach ($mailjet_template_vars as $key => $val) {
-          $html_message = str_replace($key, check_markup($val), $html_message);
+          $html_message = str_replace($key, check_markup($val, $text_format), $html_message);
           $text_message = str_replace($key, check_plain($val), $text_message);
         }
       }
@@ -307,7 +329,7 @@ function mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, 
 
     // Create Mailjet campaign content.
     $arguments_create_campaign_content = array(
-      'Html-part' => !empty($html_message) ? $html_message : check_markup($message),
+      'Html-part' => !empty($html_message) ? $html_message : check_markup($message, $text_format),
       'Text-part' => !empty($text_message) ? $text_message : check_plain($message),
     );
 


### PR DESCRIPTION
added functionality to allow admins to specify the text_format used when sanitizing markup to be sent to mailjet