### PR TITLE
issue-13: added code to strip out empty tags from rendered markup

### DIFF
--- a/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
+++ b/modules/mailjet_simple_node_campaigns/mailjet_simple_node_campaigns.module
@@ -363,6 +363,14 @@ function mailjet_simple_node_campaigns_prepare_campaign_draft($list_id, $title, 
       }
     }
 
+    // Strip empty tags from markup.
+    preg_match_all('/({{ MAILJET_SIMPLE_NODE_CAMPAIGNS_)\w+ (}})/', $html_message, $matches);
+
+    foreach ($matches[0] as $match) {
+      $html_message = str_replace($match, '', $html_message);
+      $text_message = str_replace($match, '', $text_message);
+    }
+
     // Create Mailjet campaign content.
     $arguments_create_campaign_content = array(
       'Html-part' => !empty($html_message) ? $html_message : check_markup($message, $text_format),


### PR DESCRIPTION
@andyg5000 please review this PR when you get a moment.  This will strip out all of the empty variables from templates prior to sending campaigns.